### PR TITLE
Update write.go

### DIFF
--- a/apiserver/eurekaserver/write.go
+++ b/apiserver/eurekaserver/write.go
@@ -225,6 +225,10 @@ func (h *EurekaServer) updateStatus(
 		ctx, model.CtxEventKeyMetadata, map[string]string{MetadataReplicate: strconv.FormatBool(replicated)})
 	resp := h.namingServer.UpdateInstance(ctx, &apiservice.Instance{
 		Id: &wrappers.StringValue{Value: instanceId}, Isolate: &wrappers.BoolValue{Value: isolated}})
+	// eureka实例的状态转换可能没有触发isolated的变化
+	if resp.GetCode().GetValue() == api.NoNeedUpdate {
+		return api.ExecuteSuccess
+	}
 	return resp.GetCode().GetValue()
 }
 


### PR DESCRIPTION

**Please provide issue(s) of this PR:**
Fixes  eureka status的变化可能不会触发polaris isolated的变化，此时statusUpdate方法返回ExecuteSuccess比较合理


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] ApiServer


**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
